### PR TITLE
Add progress while deleting duplicate groups

### DIFF
--- a/src/core/include/core/utils/Log.h
+++ b/src/core/include/core/utils/Log.h
@@ -8,6 +8,7 @@ namespace fs = std::filesystem;
 
 namespace tools::utl {
 
+fs::path makeLogFilename(std::string_view appName);
 void configureLogger(const fs::path& logsDir, const fs::path& logFilename);
 
 class SilenceLogger

--- a/src/core/utils/Log.cpp
+++ b/src/core/utils/Log.cpp
@@ -7,6 +7,26 @@
 
 namespace tools::utl {
 
+fs::path makeLogFilename(std::string_view appName)
+{
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+
+    std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &time);
+#else
+    localtime_r(&time, &tm);
+#endif
+
+    std::ostringstream oss;
+    oss << appName << "_"
+        << std::put_time(&tm, "%Y%m%d_%H%M%S")
+        << ".log";
+
+    return oss.str();
+}
+
 void configureLogger(const fs::path& logsDir, const fs::path& logFilename)
 {
     namespace sinks = spdlog::sinks;

--- a/src/duplicates/Config.cpp
+++ b/src/duplicates/Config.cpp
@@ -2,8 +2,8 @@
 #include <core/utils/FmtExt.h>
 #include <core/utils/Dirs.h>
 #include <core/utils/File.h>
+#include <core/utils/Log.h>
 
-#include <spdlog/spdlog.h>
 #include <toml++/toml.h>
 #include <chrono>
 #include <filesystem>
@@ -62,7 +62,7 @@ Config::Config(fs::path dataDir, fs::path cacheDir)
     dataDir_     = dirs::config() / appName;
     cacheDir_    = dirs::cache() / appName;
     logDir_      = dataDir_ / "logs";
-    logFilename_ = fmt::format("{}.log", appName);
+    logFilename_ = tools::utl::makeLogFilename(appName);
 }
 
 const std::vector<fs::path>& Config::scanDirs() const noexcept {

--- a/src/duplicates/Main.cpp
+++ b/src/duplicates/Main.cpp
@@ -80,6 +80,7 @@ int main(int argc, const char* argv[])
                          detector,
                          cfg.preferredDeletionDirs(),
                          ignored,
+                         progress,
                          std::cout,
                          std::cin);
     }

--- a/src/duplicates/include/duplicates/DuplicateDeletion.h
+++ b/src/duplicates/include/duplicates/DuplicateDeletion.h
@@ -2,7 +2,9 @@
 
 #include <duplicates/DeletionStrategy.h>
 #include <duplicates/DuplicateDetector.h>
+#include <duplicates/Progress.h>
 #include <duplicates/Config.h>
+
 #include <vector>
 #include <unordered_set>
 #include <filesystem>
@@ -86,6 +88,7 @@ bool deleteInteractively(const IDeletionStrategy& strategy,
     * @param detector The duplicate detector containing the groups of duplicates.
     * @param safeToDeleteDirs Directories where files can be safely deleted.
     * @param ignoredFiles Object to track ignored files.
+    * @param progress Object for updating progress
     * @param out Output stream for messages.
     * @param in Input stream for user interaction.
  */
@@ -93,6 +96,7 @@ void deleteDuplicates(const IDeletionStrategy& strategy,
                       const IDuplicateGroups& duplicates,
                       const PathsVec& safeToDeleteDirs,
                       IgnoredFiles& ignoredFiles,
+                      Progress& progress,
                       std::ostream& out,
                       std::istream& in);
 

--- a/test/duplicates/DuplicateDeletionTest.cpp
+++ b/test/duplicates/DuplicateDeletionTest.cpp
@@ -3,9 +3,11 @@
 
 #include <duplicates/DuplicateDeletion.h>
 #include <duplicates/DeletionStrategy.h>
+#include <duplicates/Progress.h>
 #include <core/utils/File.h>
 #include <core/utils/Log.h>
 #include <core/utils/LogInterceptor.h>
+
 #include <filesystem>
 
 using testing::MockFunction;
@@ -279,6 +281,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesInSafeDirs)
     MockDuplicateGroups groups;
     IgnoredFiles ignored;
     PathsVec safeToDeleteDirs = {"safeDir"};
+    Progress progress;
 
     // Two groups, each with two files in safeDir
     std::vector<PathsVec> groupVec
@@ -287,6 +290,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesInSafeDirs)
         {fs::path("origDir/file3.txt"), fs::path("safeDir/file4.txt")}
     };
 
+    EXPECT_CALL(groups, numGroups()).Times(1);
     EXPECT_CALL(groups, enumGroups(testing::_))
         .WillOnce([&groupVec](const DupGroupCallback& cb) {
             emulateDupGroups(groupVec, cb);
@@ -299,7 +303,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesInSafeDirs)
     std::ostringstream out;
     std::istringstream in;
 
-    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, out, in);
+    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, progress, out, in);
 }
 
 TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesAllInSafeDirs)
@@ -308,6 +312,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesAllInSafeDirs)
     MockDuplicateGroups groups;
     IgnoredFiles ignored;
     PathsVec safeToDeleteDirs = {"safeDir"};
+    Progress progress;
 
     // Two groups, each with two files in safeDir
     std::vector<PathsVec> groupVec
@@ -316,6 +321,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesAllInSafeDirs)
         {fs::path("safeDir/file3.txt"), fs::path("safeDir/file4.txt")}
     };
 
+    EXPECT_CALL(groups, numGroups()).Times(1);
     EXPECT_CALL(groups, enumGroups(testing::_))
         .WillOnce([&groupVec](const DupGroupCallback& cb) {
             emulateDupGroups(groupVec, cb);
@@ -330,7 +336,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesAllInSafeDirs)
     // delete group
     std::istringstream in("1\n1\n");
 
-    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, out, in);
+    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, progress, out, in);
 }
 
 TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesSelectively)
@@ -339,6 +345,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesSelectively)
     MockDuplicateGroups groups;
     IgnoredFiles ignored;
     PathsVec safeToDeleteDirs;
+    Progress progress;
 
     // Two groups, each with two files in safeDir
     std::vector<PathsVec> groupVec
@@ -347,6 +354,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesSelectively)
         {fs::path("origDir/file3.txt"), fs::path("dupDir/file4.txt")}
     };
 
+    EXPECT_CALL(groups, numGroups()).Times(1);
     EXPECT_CALL(groups, enumGroups(testing::_))
         .WillOnce([&groupVec](const DupGroupCallback& cb) {
             emulateDupGroups(groupVec, cb);
@@ -359,7 +367,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_ExpectedFilesSelectively)
     std::ostringstream out;
     std::istringstream in("1\n1\n"); // keep first file in the group
 
-    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, out, in);
+    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, progress, out, in);
 }
 
 TEST(DuplicateDeletionTest, DeleteDuplicates_SkipsIgnoredFiles)
@@ -369,6 +377,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_SkipsIgnoredFiles)
     MockDuplicateGroups groups;
     IgnoredFiles ignored;
     PathsVec safeToDeleteDirs = {"safeDir"};
+    Progress progress;
 
     // Mark file2.txt as ignored
     ignored.add(fs::path("safeDir/file2.txt"));
@@ -377,6 +386,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_SkipsIgnoredFiles)
         {fs::path("OrigDir/file1.txt"), fs::path("safeDir/file2.txt")}
     };
 
+    EXPECT_CALL(groups, numGroups()).Times(1);
     EXPECT_CALL(groups, enumGroups(testing::_))
         .WillOnce([&groupVec](const DupGroupCallback& cb) {
             emulateDupGroups(groupVec, cb);
@@ -387,7 +397,7 @@ TEST(DuplicateDeletionTest, DeleteDuplicates_SkipsIgnoredFiles)
     std::ostringstream out;
     std::istringstream in;
 
-    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, out, in);
+    deleteDuplicates(strategy, groups, safeToDeleteDirs, ignored, progress, out, in);
 }
 
 } // namespace tools::dups


### PR DESCRIPTION
* Add progress to the deletion process, i.e. the number of duplicate groups that are being deleted.
* Example: `Deleting duplicate group 4 out of 4737`